### PR TITLE
创建requirements.txt；makefile自动根据平台编译（需要进一步测试）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ check.xlsx
 *.png
 temp.py
 temp.csv
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@
 - [ ] 制作一个简易的图形界面
 - [ ] 编写分析UP物品抽取运气的函数
 
-### 动态库Linux编译说明
+### 动态库编译说明
 
 [GGanalysislib/bin](GGanalysislib/bin)下存放了工具包需要的动态链接库
 
-- Windows下使用的GGanalysis.dll由MinGW编译，直接在根目录下make即可
-- Linux下使用libGGanalysis.so，编译需将makefile.linux重命名为makefile，再在根目录使用gcc来make即可
-- macOS下编译过程和Linux相同
+在第一次使用时，需要在根目录下执行一次`make`以编译可用的二进制文件
+
+### 图片样例
 
 ![img](https://i0.hdslb.com/bfs/article/a78913e871d17bdf978626df6a90afeb5b3b38c1.png@942w_1079h_progressive.webp)

--- a/makefile
+++ b/makefile
@@ -1,6 +1,15 @@
+ifeq ($(OS),Windows_NT)
 ./GGanalysislib/bin/GGanalysis.dll :./source/GGanalysis.o
 	gcc -o ./GGanalysislib/bin/GGanalysis.dll ./source/GGanalysis.o -s -shared -Wl,--subsystem,windows
 ./source/GGanalysis.o : ./source/GGanalysis.c ./source/GGanalysis.h
 	gcc -c -o ./source/GGanalysis.o ./source/GGanalysis.c -O2 -D API_EXPORTS
 clean :
 	del ./GGanalysislib/source/*.o
+else
+./GGanalysislib/bin/libGGanalysis.so :./source/GGanalysis.o
+	gcc -shared -o ./GGanalysislib/bin/libGGanalysis.so ./source/GGanalysis.o
+./source/GGanalysis.o : ./source/GGanalysis.c ./source/GGanalysis.h
+	gcc -c -fPIC -o ./source/GGanalysis.o ./source/GGanalysis.c -O2 -D API_EXPORTS
+clean :
+	rm ./GGanalysislib/source/*.o
+endif

--- a/makefile.linux
+++ b/makefile.linux
@@ -1,6 +1,0 @@
-./GGanalysislib/bin/libGGanalysis.so :./source/GGanalysis.o
-	gcc -shared -o ./GGanalysislib/bin/libGGanalysis.so ./source/GGanalysis.o
-./source/GGanalysis.o : ./source/GGanalysis.c ./source/GGanalysis.h
-	gcc -c -fPIC -o ./source/GGanalysis.o ./source/GGanalysis.c -O2 -D API_EXPORTS
-clean :
-	rm ./GGanalysislib/source/*.o

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy==1.21.1
+matplotlib==3.4.3


### PR DESCRIPTION
虽然默认使用者是具有Python基础的用户，但是这边为了方便（？真的方便了吗）起见加上了`requirements.txt`。

另外，makefile我整合了一下，理论上来说不需要用户根据自己的平台选择编译脚本了。
makefile在macOS上测试通过，**但是还没有在Windows上测试过**。
这里需要进一步测试Windows平台的可用性